### PR TITLE
Do not stringify args

### DIFF
--- a/bbin
+++ b/bbin
@@ -101,17 +101,17 @@ Usage: bbin <command>
                         current-bb-version)))))))
 
 (ns babashka.bbin.scripts
-  (:require [babashka.fs :as fs]
+  (:require [babashka.bbin.util :as util :refer [sh]]
             [babashka.deps :as deps]
-            [rads.deps-info.infer :as deps-info-infer]
-            [rads.deps-info.summary :as deps-info-summary]
-            [clojure.string :as str]
+            [babashka.fs :as fs]
             [clojure.edn :as edn]
             [clojure.pprint :as pprint]
-            [selmer.parser :as selmer]
-            [selmer.util :as selmer-util]
+            [clojure.string :as str]
+            [rads.deps-info.infer :as deps-info-infer]
+            [rads.deps-info.summary :as deps-info-summary]
             [selmer.filters :as filters]
-            [babashka.bbin.util :as util :refer [sh]]))
+            [selmer.parser :as selmer]
+            [selmer.util :as selmer-util]))
 
 (defn- pprint [x _]
   (pprint/pprint x))
@@ -120,14 +120,14 @@ Usage: bbin <command>
   (let [coords (val (first script-deps))]
     (fs/expand-home (str/join fs/file-separator ["~" ".gitlibs" "libs" (:script/lib cli-opts) (:git/sha coords)]))))
 
-; windows scripts are babashka/clojure instead of shell scripts, so we need a variable 
-; comment character in the script meta
+;; windows scripts are babashka/clojure instead of shell scripts, so we need a variable
+;; comment character in the script meta
 (def ^:private comment-char
   (if util/windows? "; " "# "))
 
 (def windows-wrapper-extension ".bat")
 
-; selmer filter for clojure escaping for e.g. files
+;; selmer filter for clojure escaping for e.g. files
 (filters/add-filter! :pr-str (comp pr-str str))
 
 (def ^:private tool-template-str
@@ -152,9 +152,9 @@ Usage: bbin <command>
       [first-arg & rest-args] *command-line-args*]
   (if first-arg
     (process/exec
-      (str/join \" \" (concat [\"bb --deps-root \" SCRIPT_ROOT \"--config\" (str TMP_EDN)
+      (into [\"bb\" \"--deps-root\" SCRIPT_ROOT \"--config\" (str TMP_EDN)
                                \"-x\" (str SCRIPT_NS_DEFAULT \"/\" first-arg)
-                               \"--\"] rest-args)))
+                               \"--\"] rest-args))
     (do
       (let [script (str \"(require '\" SCRIPT_NS_DEFAULT \")
                      (def fns (filter #(fn? (deref (val %))) (ns-publics '\" SCRIPT_NS_DEFAULT \")))
@@ -170,10 +170,10 @@ Usage: bbin <command>
              cmd-line     [\"bb\" \"--deps-root\" SCRIPT_ROOT \"--config\"  (str TMP_EDN)
                            \"-e\"  script]]
          (process/exec cmd-line)))))"
-;    
-; non-windows tool script
-;
-  "#!/usr/bin/env bash
+    ;;
+    ;; non-windows tool script
+    ;;
+    "#!/usr/bin/env bash
 set -e
 
 # :bbin/start
@@ -224,23 +224,22 @@ fi"))
          '[babashka.fs :as fs]
          '[clojure.string :as str])
 
-(let [SCRIPT_ROOT    {{script/root|pr-str}}             
+(let [SCRIPT_ROOT    {{script/root|pr-str}}
       SCRIPT_LIB     '{{script/lib}}
-      SCRIPT_COORDS  {{script/coords|str}}               
+      SCRIPT_COORDS  {{script/coords|str}}
       SCRIPT_MAIN_OPTS_FIRST  {{script/main-opts.0|pr-str}}
-      SCRIPT_MAIN_OPTS_SECOND {{script/main-opts.1|pr-str}} 
+      SCRIPT_MAIN_OPTS_SECOND {{script/main-opts.1|pr-str}}
       TMP_EDN (doto (fs/file (fs/temp-dir) (str (gensym \"bbin\")))
                       (spit (str \"{:deps {\" SCRIPT_LIB SCRIPT_COORDS\"}}\"))
                       (fs/delete-on-exit))]
-                        
      (process/exec
-        (str/join \" \" (concat [\"bb --deps-root\" SCRIPT_ROOT \"--config\" (str TMP_EDN)
-                         SCRIPT_MAIN_OPTS_FIRST SCRIPT_MAIN_OPTS_SECOND
-                         \"--\"] *command-line-args*))))"
-;
-; non-windows script template
-;
-  "#!/usr/bin/env bash
+        (into [\"bb\" \"--deps-root\" SCRIPT_ROOT \"--config\" (str TMP_EDN)
+               SCRIPT_MAIN_OPTS_FIRST SCRIPT_MAIN_OPTS_SECOND
+               \"--\"] *command-line-args*)))"
+    ;;
+    ;; non-windows script template
+    ;;
+    "#!/usr/bin/env bash
 set -e
 
 # :bbin/start
@@ -263,8 +262,8 @@ exec bb \\
 
 (defn- http-url->script-name [http-url]
   (first
-    (str/split (last (str/split http-url #"/"))
-               #"\.")))
+   (str/split (last (str/split http-url #"/"))
+              #"\.")))
 
 (defn- bb-shebang? [s]
   (str/starts-with? s "#!/usr/bin/env bb"))
@@ -279,15 +278,15 @@ exec bb \\
                             ";"]
                            (map #(str "; " %)
                                 (str/split-lines
-                                  (with-out-str
-                                    (pprint/pprint header))))
+                                 (with-out-str
+                                   (pprint/pprint header))))
                            [";"
                             "; :bbin/end"]
                            code)]
     (str/join "\n" next-lines)))
 
-(defn- install-script 
-  "Spits `contents` to `path` (adding an extension on Windows), or 
+(defn- install-script
+  "Spits `contents` to `path` (adding an extension on Windows), or
   pprints them if `dry-run?` is truthy.
   Side-effecting."
   [path contents dry-run?]
@@ -295,11 +294,11 @@ exec bb \\
     (if dry-run?
       (pprint {:script-file     path-str
                :script-contents contents}
-        dry-run?)
+              dry-run?)
       (do
         (spit path-str contents)
         (when-not util/windows? (sh ["chmod" "+x" path-str]))
-        (when util/windows? 
+        (when util/windows?
           (spit (str path-str windows-wrapper-extension) (str "@bb -f %~dp0" (fs/file-name path-str) " -- %*")))
         nil))))
 
@@ -365,7 +364,7 @@ exec bb \\
                        tool-template-str
                        git-or-local-template-str)
         template-out (selmer-util/without-escaping
-                       (selmer/render template-str template-opts'))
+                      (selmer/render template-str template-opts'))
         script-file (fs/canonicalize (fs/file (util/bin-dir cli-opts) script-name) {:nofollow-links true})]
     (install-script script-file template-out (:dry-run cli-opts))))
 
@@ -383,19 +382,18 @@ exec bb \\
 (let [SCRIPT_LIB     '{{script/lib}}
       SCRIPT_COORDS  {{script/coords|str}}
       SCRIPT_MAIN_OPTS_FIRST  {{script/main-opts.0|pr-str}}
-      SCRIPT_MAIN_OPTS_SECOND {{script/main-opts.1|pr-str}} 
+      SCRIPT_MAIN_OPTS_SECOND {{script/main-opts.1|pr-str}}
       TMP_EDN (doto (fs/file (fs/temp-dir) (str (gensym \"bbin\")))
                  (spit (str \"{:deps {\" SCRIPT_LIB SCRIPT_COORDS \"}}\"))
                  (fs/delete-on-exit))]
-                                         
 (process/exec
-  (str/join \" \" (concat [\"bb --config\" (str TMP_EDN)
-                   SCRIPT_MAIN_OPTS_FIRST SCRIPT_MAIN_OPTS_SECOND
-                   \"--\"] *command-line-args*))))\""
-;
-; non-windows script template
-;  
-  "#!/usr/bin/env bash
+  (into [\"bb\" \"--config\" (str TMP_EDN)
+         SCRIPT_MAIN_OPTS_FIRST SCRIPT_MAIN_OPTS_SECOND
+         \"--\"] *command-line-args*)))"
+    ;;
+    ;; non-windows script template
+    ;;
+    "#!/usr/bin/env bash
 set -e
 
 # :bbin/start
@@ -442,7 +440,7 @@ exec bb \\
                                                              {:nofollow-links true})
                                             (second main-opts))]}
         template-out (selmer-util/without-escaping
-                       (selmer/render maven-template-str template-opts))
+                      (selmer/render maven-template-str template-opts))
         script-file (fs/canonicalize (fs/file (util/bin-dir cli-opts) script-name) {:nofollow-links true})]
     (install-script script-file template-out (:dry-run cli-opts))))
 

--- a/src/babashka/bbin/scripts.clj
+++ b/src/babashka/bbin/scripts.clj
@@ -1,16 +1,15 @@
 (ns babashka.bbin.scripts
-  (:require
-   [babashka.bbin.util :as util :refer [sh]]
-   [babashka.deps :as deps]
-   [babashka.fs :as fs]
-   [clojure.edn :as edn]
-   [clojure.pprint :as pprint]
-   [clojure.string :as str]
-   [rads.deps-info.infer :as deps-info-infer]
-   [rads.deps-info.summary :as deps-info-summary]
-   [selmer.filters :as filters]
-   [selmer.parser :as selmer]
-   [selmer.util :as selmer-util]))
+  (:require [babashka.bbin.util :as util :refer [sh]]
+            [babashka.deps :as deps]
+            [babashka.fs :as fs]
+            [clojure.edn :as edn]
+            [clojure.pprint :as pprint]
+            [clojure.string :as str]
+            [rads.deps-info.infer :as deps-info-infer]
+            [rads.deps-info.summary :as deps-info-summary]
+            [selmer.filters :as filters]
+            [selmer.parser :as selmer]
+            [selmer.util :as selmer-util]))
 
 (defn- pprint [x _]
   (pprint/pprint x))
@@ -19,14 +18,14 @@
   (let [coords (val (first script-deps))]
     (fs/expand-home (str/join fs/file-separator ["~" ".gitlibs" "libs" (:script/lib cli-opts) (:git/sha coords)]))))
 
-                                        ; windows scripts are babashka/clojure instead of shell scripts, so we need a variable
-                                        ; comment character in the script meta
+;; windows scripts are babashka/clojure instead of shell scripts, so we need a variable
+;; comment character in the script meta
 (def ^:private comment-char
   (if util/windows? "; " "# "))
 
 (def windows-wrapper-extension ".bat")
 
-                                        ; selmer filter for clojure escaping for e.g. files
+;; selmer filter for clojure escaping for e.g. files
 (filters/add-filter! :pr-str (comp pr-str str))
 
 (def ^:private tool-template-str
@@ -254,11 +253,11 @@ exec bb \\
         template-opts' (if tool-mode
                          (assoc template-opts :script/ns-default (:ns-default script-config))
                          (assoc template-opts :script/main-opts
-                                [(first main-opts)
-                                 (if (= "-f" (first main-opts))
-                                   (fs/canonicalize (fs/file script-root (second main-opts))
-                                                    {:nofollow-links true})
-                                   (second main-opts))]))
+                                              [(first main-opts)
+                                               (if (= "-f" (first main-opts))
+                                                 (fs/canonicalize (fs/file script-root (second main-opts))
+                                                                  {:nofollow-links true})
+                                                 (second main-opts))]))
         template-str (if tool-mode
                        tool-template-str
                        git-or-local-template-str)

--- a/src/babashka/bbin/scripts.clj
+++ b/src/babashka/bbin/scripts.clj
@@ -284,7 +284,7 @@ exec bb \\
       TMP_EDN (doto (fs/file (fs/temp-dir) (str (gensym \"bbin\")))
                  (spit (str \"{:deps {\" SCRIPT_LIB SCRIPT_COORDS \"}}\"))
                  (fs/delete-on-exit))]
-(process/exex
+(process/exec
   (into [\"bb\" \"--config\" (str TMP_EDN)
          SCRIPT_MAIN_OPTS_FIRST SCRIPT_MAIN_OPTS_SECOND
          \"--\"] *command-line-args*)))"


### PR DESCRIPTION
@bobisageek @rads This fixes two problems I noticed when installing and using bbin on Windows.

I noticed the arguments to `exec`, usually a string of vectors, was passed as multiple arguments that were put back using a string again. In some cases this can result in strange behaviors, so let's just keep the arguments separate using the idiom `(into [] ..)` rather than `(str/join " " (concat ...))`.

Another thing I noticed is that the maven dep script had a dangling quote. This did not cause any errors, because the `exec` call replaces the parent process before it could cause any errors, but I think it would be cleaner to remove it.

Another thing: my editor indents single `;` weird, so I made double `;;` from them.

Another thing: there was quite some dangling whitespace, which I removed using my editor.

Also I ran `lsp-organize-imports` to sort namespace requires.