### PR TITLE
support local installs on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- [local installs without aliases throw exception on Windows](https://github.com/babashka/bbin/issues/37)
+
 ## 0.1.3
 
 - [Fix script args being ignored when installing JARs](https://github.com/babashka/bbin/commit/ac85b8f984c8a30683c219d8d0faa32ef91e93e2)

--- a/bbin
+++ b/bbin
@@ -371,10 +371,10 @@ WARNING:   - Set the BABASHKA_BBIN_BIN_DIR env variable to \"$HOME/.babashka/bbi
                 #"\."))))
 
 (defn- file-path->script-name [file-path]
-  (util/snake-case
-    (first
-      (str/split (last (str/split file-path #"/"))
-                 #"\."))))
+  (-> file-path
+    fs/file-name
+    fs/strip-ext
+    util/snake-case))
 
 (defn- bb-shebang? [s]
   (str/starts-with? s "#!/usr/bin/env bb"))

--- a/src/babashka/bbin/scripts.clj
+++ b/src/babashka/bbin/scripts.clj
@@ -222,10 +222,10 @@
                 #"\."))))
 
 (defn- file-path->script-name [file-path]
-  (util/snake-case
-    (first
-      (str/split (last (str/split file-path #"/"))
-                 #"\."))))
+  (-> file-path
+    fs/file-name
+    fs/strip-ext
+    util/snake-case))
 
 (defn- bb-shebang? [s]
   (str/starts-with? s "#!/usr/bin/env bb"))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - #37 

Basically, this change uses `fs` functions to compute the script name to be more OS-agnostic. As noted on the issue, there's  _technically_ a change in behavior here, in that script names with multiple dots would be named everything up to the last dot (as opposed to everything up to the first dot), so installing 'hello.foobar.clj' would install by default as 'hello.foobar' instead of 'hello'. This seems like a corner case given clj file/namespace naming conventions.
