### PR TITLE
Fix #88: bbin ls with 0-length files doesn't crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [Fix #88: NPE when using `bbin ls` in dirs with zero-length files](https://github.com/babashka/bbin/issues/88)
+
 ## 0.2.3
 
 - [Fix error in compiled script when installing from Homebrew (again)](https://github.com/babashka/bbin/commit/f0a3096a1e57408af77eed35f86a3d71cccccb07)

--- a/src/babashka/bbin/scripts.clj
+++ b/src/babashka/bbin/scripts.clj
@@ -33,17 +33,18 @@
          edn/read-string)))
 
 (defn- read-header [filename]
-  (with-open [input-stream (io/input-stream filename)]
-    (let [buffer (byte-array (* 1024 5))
-          n (.read input-stream buffer)]
-      (when (nat-int? n)
-        (String. buffer 0 n)))))
+  (or (with-open [input-stream (io/input-stream filename)]
+        (let [buffer (byte-array (* 1024 5))
+              n (.read input-stream buffer)]
+          (when (nat-int? n)
+            (String. buffer 0 n))))
+      ""))
 
 (defn load-scripts [dir]
   (->> (file-seq dir)
        (filter #(.isFile %))
        (map (fn [x] [(symbol (str (fs/relativize dir x)))
-                     (some-> (read-header x) (parse-script ))]))
+                     (-> (read-header x) (parse-script ))]))
        (filter second)
        (into {})))
 

--- a/src/babashka/bbin/scripts.clj
+++ b/src/babashka/bbin/scripts.clj
@@ -43,7 +43,7 @@
   (->> (file-seq dir)
        (filter #(.isFile %))
        (map (fn [x] [(symbol (str (fs/relativize dir x)))
-                     (parse-script (read-header x))]))
+                     (some-> (read-header x) (parse-script ))]))
        (filter second)
        (into {})))
 


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - [ADD LINK TO ISSUE HERE](https://github.com/babashka/bbin/issues/88)
