### PR TITLE
104 provide a better error on provider lookup failure

### DIFF
--- a/bbin
+++ b/bbin
@@ -158,8 +158,13 @@ WARNING: (We won't make any changes without asking you first.)
   (->> (reduce #(str/replace %1 %2 "") lib (keys providers))
        symbol))
 
+(defn- get-lib-provider [lib]
+  (if-let [provider (some #(when (re-seq (key %) (str lib)) %) providers)]
+    provider
+    (throw (ex-info "Unable to find an appropriate provider" {:lib lib}))))
+
 (defn git-http-url [lib]
-  (let [provider (some #(when (re-seq (key %) (str lib)) %) providers)
+  (let [provider (get-lib-provider lib)
         s (clean-lib-str (str lib))]
     (case (val provider)
       :github (str "https://github.com/" s ".git")
@@ -171,7 +176,7 @@ WARNING: (We won't make any changes without asking you first.)
       :sourcehut (str "https://git.sr.ht/~" s))))
 
 (defn git-ssh-url [lib]
-  (let [provider (some #(when (re-seq (key %) (str lib)) %) providers)
+  (let [provider (get-lib-provider lib)
         s (clean-lib-str (str lib))]
     (case (val provider)
       :github (str "git@github.com:" s ".git")
@@ -187,7 +192,7 @@ WARNING: (We won't make any changes without asking you first.)
       (ensure-git-dir client url)
       url)
     (catch Exception e
-      (if (re-seq #"^Unable to clone " (ex-message e))
+      (if (re-seq #"^Unable to " (ex-message e))
         (let [url (git-ssh-url lib)]
           (ensure-git-dir client url)
           url)

--- a/src/babashka/bbin/git.clj
+++ b/src/babashka/bbin/git.clj
@@ -69,7 +69,7 @@
       :sourcehut (str "https://git.sr.ht/~" s))))
 
 (defn git-ssh-url [lib]
-  (let [provider (some #(when (re-seq (key %) (str lib)) %) providers)
+  (let [provider (get-lib-provider lib)
         s (clean-lib-str (str lib))]
     (case (val provider)
       :github (str "git@github.com:" s ".git")

--- a/src/babashka/bbin/git.clj
+++ b/src/babashka/bbin/git.clj
@@ -51,8 +51,13 @@
   (->> (reduce #(str/replace %1 %2 "") lib (keys providers))
        symbol))
 
+(defn- get-lib-provider [lib]
+  (if-let [provider (some #(when (re-seq (key %) (str lib)) %) providers)]
+    provider
+    (throw (ex-info "Unable to find an appropriate provider" {:lib lib}))))
+
 (defn git-http-url [lib]
-  (let [provider (some #(when (re-seq (key %) (str lib)) %) providers)
+  (let [provider (get-lib-provider lib)
         s (clean-lib-str (str lib))]
     (case (val provider)
       :github (str "https://github.com/" s ".git")
@@ -80,7 +85,7 @@
       (ensure-git-dir client url)
       url)
     (catch Exception e
-      (if (re-seq #"^Unable to clone " (ex-message e))
+      (if (re-seq #"^Unable to " (ex-message e))
         (let [url (git-ssh-url lib)]
           (ensure-git-dir client url)
           url)

--- a/test/babashka/bbin/scripts/git_dir_test.clj
+++ b/test/babashka/bbin/scripts/git_dir_test.clj
@@ -89,3 +89,11 @@
       (is (= git-ssh-url-lib out))
       (is (fs/exists? bin-file))
       (is (= "Hello world!" (tu/run-bin-script 'hello))))))
+
+(deftest install-lib-fail-if-provider-not-found
+  (testing "install lib name fails provider lookup"
+    (tu/reset-test-dir)
+    (dirs/ensure-bbin-dirs {})
+    (let [cli-opts {:script/lib "something-broken"}]
+      (is (thrown? Exception "Unable to find an appropriate provider" (tu/run-install cli-opts)))
+      )))


### PR DESCRIPTION
If the lib name does not match any of the expected providers, for example github or bitbucket, then the lookup will return nil and the subsequent call to `clean-lib-str` will throw a NullPointerException.

fix #104 
[bbin install fails with NullPointerException if the lib name fails the provider lookup](https://github.com/babashka/bbin/issues/104)
